### PR TITLE
Include email and correspondence language in people filter

### DIFF
--- a/app/domain/die_mitte/person/filter/attributes.rb
+++ b/app/domain/die_mitte/person/filter/attributes.rb
@@ -1,0 +1,30 @@
+#  Copyright (c) 2021, Die Mitte. This file is part of
+#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_die_mitte.
+
+module DieMitte::Person::Filter::Attributes
+
+  I18N_KEY = 'activerecord.attributes.person.correspondence_languages'.freeze
+
+  def persisted_attribute_condition_sql(key, value, constraint)
+    if key == 'correspondence_language' && value.present?
+      value = from_translations(value)&.first || value
+    end
+
+    super(key, value, constraint)
+  end
+
+  def from_translations(value)
+    translations.find { |_, list| list.any? { |item| item.downcase.match(value.downcase) } }
+  end
+
+  def translations
+    @translations ||= Settings.application.languages.keys.each_with_object({}) do |lang, memo|
+      I18n.t(I18N_KEY, locale: lang).each do |key, value|
+        memo[key] ||= []
+        memo[key] << value
+      end
+    end.stringify_keys
+  end
+end

--- a/lib/hitobito_die_mitte/wagon.rb
+++ b/lib/hitobito_die_mitte/wagon.rb
@@ -23,6 +23,8 @@ module HitobitoDieMitte
       Role.send         :include, DieMitte::Role
       Person.send       :include, DieMitte::Person
 
+      Person::FILTER_ATTRS << :correspondence_language << :email
+
       RoleDecorator.send :prepend, DieMitte::RoleDecorator
       GroupDecorator.send :prepend, DieMitte::GroupDecorator
       # rubocop:enable SingleSpaceBeforeFirstArg
@@ -30,6 +32,9 @@ module HitobitoDieMitte
 
       PeopleController.send :prepend, DieMitte::PeopleController
       FilterNavigation::People.send :prepend, DieMitte::FilterNavigation::People
+
+
+      Person::Filter::Attributes.send :prepend, DieMitte::Person::Filter::Attributes
 
       Export::Pdf::Messages::Letter::Content.placeholders << :salutation
       Export::Pdf::Messages::Letter::Content.send :prepend,

--- a/spec/domain/person/filter/attributes_spec.rb
+++ b/spec/domain/person/filter/attributes_spec.rb
@@ -1,0 +1,54 @@
+#  Copyright (c) 2021, Die Mitte. This file is part of
+#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_die_mitte.
+
+require "spec_helper"
+
+describe Person::Filter::Attributes do
+  let(:user)         { people(:sekretaer) }
+  let(:group)        { groups(:die_mitte) }
+
+  def filter(value)
+    Person::Filter::List.new(
+      group,
+      user,
+      range: 'deep',
+      filters: {
+        attributes: {
+          '1234567890123': {
+            key: key,
+            constraint: 'match',
+            value: value
+          }
+        }
+      }
+    )
+  end
+
+  context :correspondence_language do
+    let(:key) { "correspondence_language" }
+
+    it "finds three if blank" do
+      expect(filter(nil).entries).to have(3).items
+      expect(filter("").entries).to have(3).items
+    end
+
+    it "finds none if not matching" do
+      expect(filter("invalid").entries).to be_empty
+    end
+
+    it "finds two with correspondence_language de" do
+      expect(filter("de").entries).to have(2).items
+      expect(filter("Deutsch").entries).to have(2).items
+      expect(filter("Allemand").entries).to have(2).items
+      expect(filter("allemand").entries).to have(2).items
+    end
+
+    it "finds one with correspondence_language en" do
+      expect(filter("en").entries).to have(1).items
+      expect(filter("inglese").entries).to have(1).items
+    end
+  end
+
+end


### PR DESCRIPTION
Fügt `email` und `correspondence_langage` zum AttributFilter auf der Person hinzu. Besser als dieser Textbasierte filter wäre sicher ein Dropdown für I18n. 

refs hitobito/hitobito_die_mitte#128, 
refs hitobito/hitobito_die_mitte#130