### PR TITLE
Add correspondence language filter on mailing_list

### DIFF
--- a/app/domain/die_mitte/mailing_list/subscribers.rb
+++ b/app/domain/die_mitte/mailing_list/subscribers.rb
@@ -1,0 +1,19 @@
+#  Copyright (c) 2021, Die Mitte. This file is part of
+#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_die_mitte.
+
+module DieMitte::MailingList::Subscribers
+
+  def people
+    super.where(correspondence_language_condition)
+  end
+
+  private
+
+  def correspondence_language_condition
+    return {} if @list.correspondence_language.blank?
+
+    { correspondence_language: @list.correspondence_language }
+  end
+end

--- a/app/helpers/mailing_list_die_mitte_helper.rb
+++ b/app/helpers/mailing_list_die_mitte_helper.rb
@@ -1,0 +1,13 @@
+#  Copyright (c) 2021, Die Mitte. This file is part of
+#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_die_mitte.
+
+module MailingListDieMitteHelper
+  I18N_KEY = 'activerecord.attributes.person.correspondence_languages'.freeze
+
+  def format_mailing_list_correspondence_language(mailing_list)
+    lang = mailing_list.correspondence_language
+    lang.present? ? I18n.t([I18N_KEY, lang].join('.')) : t('global.all')
+  end
+end

--- a/app/views/mailing_lists/_attrs_die_mitte.html.haml
+++ b/app/views/mailing_lists/_attrs_die_mitte.html.haml
@@ -1,0 +1,6 @@
+-#  Copyright (c) 2021, Die Mitte. This file is part of
+-#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_die_mitte.
+
+= render_attrs(entry, :correspondence_language)

--- a/app/views/mailing_lists/_fields_die_mitte.html.haml
+++ b/app/views/mailing_lists/_fields_die_mitte.html.haml
@@ -1,0 +1,7 @@
+-#  Copyright (c) 2021, Die Mitte. This file is part of
+-#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_die_mitte.
+
+%fieldset
+  = f.labeled_collection_select(:correspondence_language, Person.correspondence_language_labels, :first, :second, include_blank: I18n.t('global.all'))

--- a/config/locales/models.die_mitte.de.yml
+++ b/config/locales/models.die_mitte.de.yml
@@ -506,6 +506,8 @@ de:
               other: Sehr geehrte*r Frau*Herr %{title_last_name}
 
     attributes:
+      mailing_list:
+        correspondence_language: Korrespondenzsprache
       person:
         salutation: Anrede
         salutation_value: Anrede

--- a/db/migrate/20210323083009_add_correspondence_language_field_to_mailing_lists.rb
+++ b/db/migrate/20210323083009_add_correspondence_language_field_to_mailing_lists.rb
@@ -1,0 +1,12 @@
+#  Copyright (c) 2021, Die Mitte. This file is part of
+#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_die_mitte.
+
+class AddCorrespondenceLanguageFieldToMailingLists < ActiveRecord::Migration[6.0]
+  def change
+    change_table :mailing_lists do |t|
+      t.string :correspondence_language
+    end
+  end
+end

--- a/lib/hitobito_die_mitte/wagon.rb
+++ b/lib/hitobito_die_mitte/wagon.rb
@@ -28,12 +28,16 @@ module HitobitoDieMitte
       # rubocop:enable SingleSpaceBeforeFirstArg
       Event.role_types -= [Event::Role::Cook]
 
+      MailingListsController.permitted_attrs << :correspondence_language
+
       PeopleController.send :prepend, DieMitte::PeopleController
       FilterNavigation::People.send :prepend, DieMitte::FilterNavigation::People
 
       Export::Pdf::Messages::Letter::Content.placeholders << :salutation
       Export::Pdf::Messages::Letter::Content.send :prepend,
                                                   DieMitte::Export::Pdf::Messages::Letter::Content
+
+      MailingList::Subscribers.send :prepend, DieMitte::MailingList::Subscribers
     end
 
     initializer 'die_mitte.add_settings' do |_app|

--- a/spec/domain/mailing_list/subscribers_spec.rb
+++ b/spec/domain/mailing_list/subscribers_spec.rb
@@ -1,0 +1,34 @@
+#  Copyright (c) 2021, Die Mitte. This file is part of
+#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_die_mitte.
+#
+require "spec_helper"
+
+describe MailingList::Subscribers do
+  let(:list) { mailing_lists(:list) }
+  let(:group) { groups(:sekretariat) }
+
+  context "correspondence_language" do
+    let!(:other) do
+      Fabricate(Group::BundSekretariat::Leitung.sti_name, group: group).person.tap do |person|
+        person.update(correspondence_language: :de)
+      end
+    end
+
+    it "includes two people if nil" do
+      list.update(correspondence_language: nil)
+      expect(list.people).to have(2).items
+    end
+
+    it "includes two people if blank" do
+      list.update(correspondence_language: "")
+      expect(list.people).to have(2).items
+    end
+
+    it "includes single perosn when set" do
+      list.update(correspondence_language: :de)
+      expect(list.people).to eq [other]
+    end
+  end
+end

--- a/spec/fixtures/mailing_lists.yml
+++ b/spec/fixtures/mailing_lists.yml
@@ -1,0 +1,11 @@
+#  Copyright (c) 2021, Die Mitte. This file is part of
+#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_die_mitte.
+
+---
+list:
+  name: Sekretäre
+  group: sekretariat
+  mail_name: sekretaere
+  subscribable: true

--- a/spec/fixtures/related_role_types.yml
+++ b/spec/fixtures/related_role_types.yml
@@ -1,0 +1,9 @@
+#  Copyright (c) 2021, Die Mitte. This file is part of
+#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_die_mitte.
+
+leader_groups_bottom_layer:
+  relation: list_subscribers
+  relation_type: Subscription
+  role_type: Group::BundSekretariat::Leitung

--- a/spec/fixtures/subscriptions.yml
+++ b/spec/fixtures/subscriptions.yml
@@ -1,0 +1,9 @@
+#  Copyright (c) 2021, Die Mitte. This file is part of
+#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_die_mitte.
+
+list_subscribers:
+  subscriber: sekretariat
+  subscriber_type: Group
+  mailing_list: list


### PR DESCRIPTION
Wir haben uns dafür entschieden den Filter direkt auf der MailingListe zu machen, eine Einstellung pro Subscription (Person, Group, Event) verwirrend sein kann. 

refs hitobito/hitobito_die_mitte#128