### PR TITLE
Übersetzung der Rollenbezeichnung ermöglichen

### DIFF
--- a/app/indices/person_index.rb
+++ b/app/indices/person_index.rb
@@ -8,5 +8,5 @@
 module PersonIndex; end
 
 ThinkingSphinx::Index.define_partial :person do
-  indexes roles.label
+  indexes roles.translations.label
 end

--- a/app/models/die_mitte/normalized_labels.rb
+++ b/app/models/die_mitte/normalized_labels.rb
@@ -6,7 +6,7 @@
 #  https://github.com/hitobito/hitobito_die_mitte.
 
 module DieMitte::NormalizedLabels
-  def available_labels(lang)
+  def available_labels(lang = I18n.locale)
     Rails.cache.fetch(labels_cache_key(lang)) do
       load_available_labels(lang)
     end

--- a/app/models/die_mitte/normalized_labels.rb
+++ b/app/models/die_mitte/normalized_labels.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Die Mitte. This file is part of
+#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_die_mitte.
+
+module DieMitte::NormalizedLabels
+  def available_labels(lang)
+    Rails.cache.fetch(labels_cache_key(lang)) do
+      load_available_labels(lang)
+    end
+  end
+
+  def sweep_available_labels
+    Settings.application.languages.keys.each do |key|
+      Rails.cache.delete(labels_cache_key(key))
+    end
+  end
+
+  private
+
+  def load_available_labels(lang)
+    predefined_labels(lang) |
+      base_class.with_translations(lang).order(:label).distinct.pluck(:label).compact
+  end
+
+  def predefined_labels(_lang)
+    []
+  end
+
+  def labels_cache_key(lang)
+    "#{base_class.name}.Labels.#{lang}"
+  end
+end

--- a/app/models/die_mitte/role.rb
+++ b/app/models/die_mitte/role.rb
@@ -9,6 +9,8 @@ module DieMitte::Role
   extend ActiveSupport::Concern
 
   included do
+    translates :label
+
     alias_method_chain :to_s, :merkmal
   end
 

--- a/app/models/die_mitte/role.rb
+++ b/app/models/die_mitte/role.rb
@@ -5,11 +5,17 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_die_mitte.
 
+require 'globalize-accessors'
+
 module DieMitte::Role
   extend ActiveSupport::Concern
 
   included do
     translates :label
+    globalize_accessors locales: Settings.application.languages.keys,
+                        attributes: [:label]
+
+    self.used_attributes += globalize_attribute_names
 
     alias_method_chain :to_s, :merkmal
   end

--- a/app/views/roles/_fields.html.haml
+++ b/app/views/roles/_fields.html.haml
@@ -1,0 +1,29 @@
+-# copied from core because I want to replace ALL the label-fields
+
+- if @group_selection.present? && @group_selection.size > 1
+  = f.labeled(:group_id) do
+    .span6.shown
+      = f.select(:group_id,
+                 group_options_with_level,
+                 { },
+                 { class: 'chosen-select',
+                   data: { remote: true,
+                           url: role_types_group_roles_path(@group),
+                           chosen_no_results: t('global.chosen_no_results') } })
+- else
+  = f.hidden_field :group_id
+
+= f.labeled(:type) do
+  #role_type_select.span6
+    = render 'roles/type_select'
+
+= field_set_tag Role.human_attribute_name(:label) do
+  - Settings.application.languages.each do |code, name|
+    = f.labeled_input_field(:"label_#{code}",
+                            data: { provide: :typeahead, source: entry.klass.available_labels },
+                            label: name)
+
+  %small
+    = t('.help_optional_label')
+
+= render_extensions :fields, locals: { f: f }

--- a/app/views/roles/_fields.html.haml
+++ b/app/views/roles/_fields.html.haml
@@ -20,7 +20,7 @@
 = field_set_tag Role.human_attribute_name(:label) do
   - Settings.application.languages.each do |code, name|
     = f.labeled_input_field(:"label_#{code}",
-                            data: { provide: :typeahead, source: entry.klass.available_labels },
+                            data: { provide: :typeahead, source: entry.klass.available_labels(code) },
                             label: name)
 
   %small

--- a/db/migrate/20210713233600_translate_role_labels.rb
+++ b/db/migrate/20210713233600_translate_role_labels.rb
@@ -9,26 +9,28 @@ class TranslateRoleLabels < ActiveRecord::Migration[6.0]
       })
     end
 
-    I18n.with_locale(:fr) do
-      say_with_time('migrate role-labels for french groups') do
-        [
-          158, 164, 174, 155, 159, 162, 176, 172,
-          108, 37563, 98, 100, 119, 241, 38742, 38800, 36851, 255, 52966, 257
-        ].each do |group_id|
-          role_group_ids = Group.find(group_id).descendants.pluck(:id)
+    if Rails.env.production?
+      I18n.with_locale(:fr) do
+        say_with_time('migrate role-labels for french groups') do
+          [
+            158, 164, 174, 155, 159, 162, 176, 172,
+            108, 37563, 98, 100, 119, 241, 38742, 38800, 36851, 255, 52966, 257
+          ].each do |group_id|
+            role_group_ids = Group.find(group_id).descendants.pluck(:id)
 
-          next if role_group_ids.empty?
+            next if role_group_ids.empty?
 
-          say "migrating roles in #{role_group_ids.count} subgroups", true
-          migrate_role_labels(I18n.locale, "group_id IN (#{role_group_ids.join(', ')})")
+            say "migrating roles in #{role_group_ids.count} subgroups", true
+            migrate_role_labels(I18n.locale, "group_id IN (#{role_group_ids.join(', ')})")
+          end
         end
       end
     end
 
+    # everything else
     I18n.with_locale(:de) do
       say_with_time('migrate role-labels for german groups') do
-        labeled_roles = Role
-          .where("#{Role.quoted_table_name}.label IS NULL OR #{Role.quoted_table_name}.label = ''")
+        labeled_roles = Role.where("roles.label IS NULL OR roles.label = ''")
 
         total = (labeled_roles.count / 1000.0).ceil
 

--- a/db/migrate/20210713233600_translate_role_labels.rb
+++ b/db/migrate/20210713233600_translate_role_labels.rb
@@ -1,0 +1,75 @@
+class TranslateRoleLabels < ActiveRecord::Migration[6.0]
+  def up
+    say_with_time('creating translation table for roles') do
+      Role.create_translation_table!({
+        :label => :string
+      }, {
+        :migrate_data => false,
+        :remove_source_columns => false
+      })
+    end
+
+    I18n.with_locale(:fr) do
+      say_with_time('migrate role-labels for french groups') do
+        [
+          158, 164, 174, 155, 159, 162, 176, 172,
+          108, 37563, 98, 100, 119, 241, 38742, 38800, 36851, 255, 52966, 257
+        ].each do |group_id|
+          role_group_ids = Group.find(group_id).descendants.pluck(:id)
+
+          next if role_group_ids.empty?
+
+          say "migrating roles in #{role_group_ids.count} subgroups", true
+          migrate_role_labels(I18n.locale, "group_id IN (#{role_group_ids.join(', ')})")
+        end
+      end
+    end
+
+    I18n.with_locale(:de) do
+      say_with_time('migrate role-labels for german groups') do
+        labeled_roles = Role
+          .where("#{Role.quoted_table_name}.label IS NULL OR #{Role.quoted_table_name}.label = ''")
+
+        total = (labeled_roles.count / 1000.0).ceil
+
+        labeled_roles
+          .select(:id)
+          .in_batches
+          .each_with_index do |role_batch, idx|
+            say "migrating roles batch #{idx.succ} of #{total}", true
+            migrate_role_labels(I18n.locale, "id IN (#{role_batch.map(&:id).join(', ')})")
+          end
+      end
+    end
+
+    remove_column(:roles, :label)
+  end
+
+  def down
+    say_with_time('dropping translation-table for roles') do
+      Role.drop_translation_table! :migrate_data => true
+    end
+  end
+
+  private
+
+  def migrate_role_labels(locale, condition)
+    suppress_messages do
+      execute <<~SQL.split.join(' ')
+        INSERT INTO #{Role.translations_table_name}
+               (locale, role_id, label, created_at, updated_at)
+        SELECT '#{locale}' AS locale, id AS role_id, label,
+               NOW() AS created_at, NOW() AS updated_at
+        FROM roles
+        WHERE (label != '' AND label IS NOT NULL)
+        AND #{condition}
+      SQL
+
+      execute <<~SQL.split.join(' ')
+        UPDATE #{Role.table_name}
+        SET label = NULL
+        WHERE #{condition}
+      SQL
+    end
+  end
+end

--- a/hitobito_die_mitte.gemspec
+++ b/hitobito_die_mitte.gemspec
@@ -1,11 +1,12 @@
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
 # Maintain your wagon's version:
 require 'hitobito_die_mitte/version'
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  # rubocop:disable SingleSpaceBeforeFirstArg
   s.name        = 'hitobito_die_mitte'
   s.version     = HitobitoDieMitte::VERSION
   s.authors     = ['Andreas Maierhofer']
@@ -15,5 +16,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*'] + ['Rakefile']
   s.test_files = Dir['test/**/*']
-  # rubocop:enable SingleSpaceBeforeFirstArg
+
+  s.add_dependency 'globalize-accessors'
 end

--- a/lib/hitobito_die_mitte/wagon.rb
+++ b/lib/hitobito_die_mitte/wagon.rb
@@ -21,6 +21,7 @@ module HitobitoDieMitte
       # extend application classes here
       Group.include DieMitte::Group
       Role.include DieMitte::Role
+      Role.extend DieMitte::NormalizedLabels
       Person.include DieMitte::Person
 
       Person::FILTER_ATTRS << :correspondence_language << :email


### PR DESCRIPTION
Fixes #178

Es ist möglich und eigentlich ausreichend, das Label-Feld im Wagon zu übersetzen. Um eine leichtere Bearbeitung zu ermöglichen und gleichzeitig während des Bearbeitens das I18n-Fallback zu deaktivieren, habe ich `globalize-accessors` hinzugefügt. Dadurch kann man `label_de` usw. verwenden, um spezifische Übersetzungen zu bearbeiten oder auszulesen. Nachteil ist, dass ich das ganze `_fields`-partial überschreiben musste, um die richtigen Felder zu bekommen.

Die Migration mit Bordmitteln war zu langsam, weil sie jede DB-Zeile einzeln in ein AR-Objekt geladen hat und dann die Übersetzung ggf. separiert hat. Mit SQL und etwas Ruby konnte ich diese mindestens mehrminütige Migration (ich hatte auch nach 15 Minuten kein Feedback und abgebrochen) in 20 Sekunden ablaufen lassen. Nebeneffekt ist, dass nun auch hoffentlich hilfreiche Informationen während der Abarbeitung ausgegeben werden.